### PR TITLE
Added options.type and options.format with a little bit of refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ Examples:
     console.log(randomWords({exactly: 5, maxLength: 4}))
     ['army','come','eye','five','fur']
 
+    console.log(randomWords({exactly:5, wordsPerString:2}))
+    [ 'salt practical', 'also brief', 'country muscle', 'neighborhood beyond', 'grew pig' ]
+
+    console.log(randomWords({exactly:5, wordsPerString:2, separator:'-'}))
+    [ 'equator-variety', 'salt-usually', 'importance-becoming', 'stream-several', 'goes-fight' ]
+
+    console.log(randomWords({exactly:5, wordsPerString:2, formatter: (word)=> word.toUpperCase()}))
+    [ 'HAVING LOAD', 'LOST PINE', 'GAME SLOPE', 'SECRET GIANT', 'INDEED LOCATION' ]
+
+    console.log(randomWords({exactly:5, wordsPerString:2, formatter: (word, index)=> {
+        return index === 0 ? word.slice(0,1).toUpperCase().concat(word.slice(1)) : word;
+    }}))
+    [ 'Until smoke', 'Year strength', 'Pay knew', 'Fallen must', 'Chief arrow' ]

--- a/index.js
+++ b/index.js
@@ -277,6 +277,32 @@ function words(options) {
     return Math.floor(Math.random() * lessThan);
   }
 
+  function formatter(word){
+    switch(options.format.toUpperCase()){
+      case "PASCALCASE":
+        return word.toString().slice(0,1).toUpperCase().concat(word.toString().slice(1))
+      default:
+        return word;
+      }
+  }
+
+  function defaultPopulator(){
+    for (var i = 0; (i < total); i++) {
+      results.push(formatter( word() ));
+    }
+  }
+
+  function pairsPopulator(){
+    var token='';
+    for(var i = 0; i < (total*2); i++){
+        token += formatter( generateRandomWord() );
+        if ((i+1) % 2 === 0) {
+          results.push(token);
+          token = "";
+        }
+    }
+  }
+
   // No arguments = generate one word
   if (typeof(options) === 'undefined') {
     return word();
@@ -287,6 +313,16 @@ function words(options) {
     options = { exactly: options };
   }
 
+  //if type is undefined set it to 'null'
+  if(typeof(options.type) === 'undefined') {
+    options.type = 'null';
+  }
+  
+  //if no format is requested set it to 'null'
+  if(typeof(options.format) === 'undefined') {
+    options.format = 'null';
+  }
+
   // options supported: exactly, min, max, join
   if (options.exactly) {
     options.min = options.exactly;
@@ -295,15 +331,24 @@ function words(options) {
   var total = options.min + randInt(options.max + 1 - options.min);
   var results = [];
 
-  for (var i = 0; (i < total); i++) {
-    results.push(word());
+  var type = options.type.toUpperCase();
+  
+  switch(type){
+    case "PAIRS":
+      pairsPopulator();
+      break;
+    default:
+      defaultPopulator();
+      break;
   }
+
   if (options.join) {
     results = results.join(options.join);
   }
 
   return results;
 }
+
 
 module.exports = words;
 // Export the word list as it is often useful

--- a/index.js
+++ b/index.js
@@ -305,13 +305,13 @@ function words(options) {
 
   //not a string = separator is a space
   if (typeof(options.separator) !== 'string') {
-    options.separator= ' ';
+    options.separator = ' ';
   }
 
   var total = options.min + randInt(options.max + 1 - options.min);
   var results = [];
   var token = '';
-  var relativeIndex=0;
+  var relativeIndex = 0;
 
   for (var i = 0; (i < total * options.wordsPerString); i++) {
     if (relativeIndex === options.wordsPerString - 1) {
@@ -321,10 +321,10 @@ function words(options) {
       token += options.formatter(word(), relativeIndex) + options.separator;
     }
     relativeIndex++;
-    if ((i+1) % options.wordsPerString === 0) {
+    if ((i + 1) % options.wordsPerString === 0) {
       results.push(token);
-      token=''; 
-      relativeIndex=0;
+      token = ''; 
+      relativeIndex = 0;
     }
    
   }

--- a/index.js
+++ b/index.js
@@ -298,17 +298,35 @@ function words(options) {
     options.wordsPerString = 1;
   }
 
+  //not a function = returns the raw word
+  if (typeof(options.formatter) !== 'function') {
+    options.formatter = (word) => word;
+  }
+
+  //not a string = separator is a space
+  if (typeof(options.separator) !== 'string') {
+    options.separator= ' ';
+  }
+
   var total = options.min + randInt(options.max + 1 - options.min);
   var results = [];
   var token = '';
+  var relativeIndex=0;
 
   for (var i = 0; (i < total * options.wordsPerString); i++) {
-    token += word();
+    if (relativeIndex === options.wordsPerString - 1) {
+      token += options.formatter(word(), relativeIndex);
+    }
+    else {
+      token += options.formatter(word(), relativeIndex) + options.separator;
+    }
+    relativeIndex++;
     if ((i+1) % options.wordsPerString === 0) {
       results.push(token);
-      token='';
+      token=''; 
+      relativeIndex=0;
     }
-    
+   
   }
   if (options.join) {
     results = results.join(options.join);

--- a/index.js
+++ b/index.js
@@ -277,32 +277,6 @@ function words(options) {
     return Math.floor(Math.random() * lessThan);
   }
 
-  function formatter(word){
-    switch(options.format.toUpperCase()){
-      case "PASCALCASE":
-        return word.toString().slice(0,1).toUpperCase().concat(word.toString().slice(1))
-      default:
-        return word;
-      }
-  }
-
-  function defaultPopulator(){
-    for (var i = 0; (i < total); i++) {
-      results.push(formatter( word() ));
-    }
-  }
-
-  function pairsPopulator(){
-    var token='';
-    for(var i = 0; i < (total*2); i++){
-        token += formatter( generateRandomWord() );
-        if ((i+1) % 2 === 0) {
-          results.push(token);
-          token = "";
-        }
-    }
-  }
-
   // No arguments = generate one word
   if (typeof(options) === 'undefined') {
     return word();
@@ -313,35 +287,29 @@ function words(options) {
     options = { exactly: options };
   }
 
-  //if type is undefined set it to 'null'
-  if(typeof(options.type) === 'undefined') {
-    options.type = 'null';
-  }
-  
-  //if no format is requested set it to 'null'
-  if(typeof(options.format) === 'undefined') {
-    options.format = 'null';
-  }
-
   // options supported: exactly, min, max, join
   if (options.exactly) {
     options.min = options.exactly;
     options.max = options.exactly;
   }
-  var total = options.min + randInt(options.max + 1 - options.min);
-  var results = [];
-
-  var type = options.type.toUpperCase();
   
-  switch(type){
-    case "PAIRS":
-      pairsPopulator();
-      break;
-    default:
-      defaultPopulator();
-      break;
+  // not a number = one word par string
+  if (typeof(options.wordsPerString) !== 'number') {
+    options.wordsPerString = 1;
   }
 
+  var total = options.min + randInt(options.max + 1 - options.min);
+  var results = [];
+  var token = '';
+
+  for (var i = 0; (i < total * options.wordsPerString); i++) {
+    token += word();
+    if ((i+1) % options.wordsPerString === 0) {
+      results.push(token);
+      token='';
+    }
+    
+  }
   if (options.join) {
     results = results.join(options.join);
   }
@@ -349,8 +317,6 @@ function words(options) {
   return results;
 }
 
-
 module.exports = words;
 // Export the word list as it is often useful
 words.wordList = wordList;
-

--- a/tests/test.js
+++ b/tests/test.js
@@ -37,6 +37,31 @@ describe('random-words', function() {
     words.forEach(word => {
       assert.ok(word.length <= maxWordSize && word.length > 0, 'result is smaller than max size: ' + maxWordSize)
     });
-  });  
+  });
+  it('should return 5 space separated words for each string if wordsPerString is set to 5 and exactly > 1', function() {
+    var words = randomWords({exactly:10, wordsPerString:5});
+    words.forEach(string => {
+      stringSplitted = string.split(' ');
+      assert.ok(stringSplitted.length === 5, 'the i-th string contains 5 words');
+    });
+  });
+  it('should reuturn 5 words separated by a separator for each string if wordsPerString > 1, separator is defined as a string and exactly > 1', function() {
+    const separator = '-';
+    var words = randomWords({exactly:10, wordsPerString:5, separator});
+    words.forEach(string => {
+      stringSplitted = string.split(separator);
+      assert.ok(typeof(separator) === 'string', 'separator is a string');
+      assert.ok(stringSplitted.length === 5, 'the i-th string contains 5 words');
+    });
+  });
+  it('should return styled strings if formatter is defined as a function that returns a string', function() {
+    formatter = (word) => word.toUpperCase();
+    assert.ok(typeof(formatter) === 'function', 'formatter is a function');
+    assert.ok(typeof(formatter('test')) === 'string', 'formatter returns a string');
+    var words = randomWords({exactly:10, formatter});
+    words.forEach(word => {
+      assert.ok(word === word.toUpperCase(), 'word is formatted')
+    });
+  });
 });
 


### PR DESCRIPTION
**options.type** is a _string_ that defines how the results array will be populated. ( I implemented the "PAIRS" type ).
**options.format** is a _string_ that defines how words will be formatted. (I implemented the "PASCALCASE" type).
if **type** and **format** are not defined or are different than any case in the switch statements, than it all works as default.

I implemented this because I published an article on Medium. I made a React Native version of the Flutter's "Write your first Flutter app". ( you can find it [here](https://medium.com/@mattveraldi/flutter-write-your-first-flutter-app-in-react-native-1e468ab8655b) ).
To do that I used a function on top of _random-words_ to do the same thing that the _english_words_ Flutter's package does. Then I thought to make a pull request so that anyone can use it.