### PR TITLE
No need to have two module.exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,6 +335,7 @@ function words(options) {
   return results;
 }
 
-module.exports = words;
-// Export the word list as it is often useful
-words.wordList = wordList;
+module.exports = {
+  words,
+  wordList
+}


### PR DESCRIPTION
There is no need to have two module.exports whenever you can easily just use one. Makes for cleaner code