### PR TITLE
update mocha to version 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   "author": "Thomas Boutell",
   "license": "MIT",
   "devDependencies": {
-    "mocha": "^7.1.1"
+    "mocha": "^9.1.3"
   }
 }


### PR DESCRIPTION
mocha v7 has a dependency with a security vulnerability. I've updated the package file to point to a newer version of mocha. All tests still pass. 